### PR TITLE
missing zero fields coppa,instl,allimp,test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Check [this doc](https://github.com/seedtag/openrtb/blob/seedtag_main/SEEDTAG.md) for seedtag changes.
+
 # openrtb [![Go Reference](https://pkg.go.dev/badge/github.com/prebid/openrtb/v20.svg)](https://pkg.go.dev/github.com/prebid/openrtb/v20) [![Test](https://github.com/prebid/openrtb/actions/workflows/test.yml/badge.svg)](https://github.com/prebid/openrtb/actions/workflows/test.yml)
 
 [OpenRTB](https://iabtechlab.com/standards/openrtb/), [AdCOM](https://iabtechlab.com/standards/openmedia) and [OpenRTB Dynamic Native Ads](https://iabtechlab.com/standards/openrtb-native/) types for [Go programming language](https://golang.org/)

--- a/SEEDTAG.md
+++ b/SEEDTAG.md
@@ -1,11 +1,17 @@
 ## Seedtag's OpenRTB
 
-This library is forked as a close copy of previd/openrtb but with neccesary changes to operate at Seedtag.
+This library has been forked from prebid/openrtb and our goal is to make the minimum neccessary changes to operate at Seedtag.
 
+## Development flow
 
+Key points:
+- main remains unchanged to be able to sync from upstream
+- seedtag_main will be main with the custom changes, where we plug our repositories
 
 
 ## What's different from prebid/openrtb
+
+Here we list all the changes that have been done to the original protocol at prebid/openrtb.
 
 ### default=0 and omitempty
 

--- a/SEEDTAG.md
+++ b/SEEDTAG.md
@@ -1,0 +1,30 @@
+## Seedtag's OpenRTB
+
+This library is forked as a close copy of previd/openrtb but with neccesary changes to operate at Seedtag.
+
+
+
+
+## What's different from prebid/openrtb
+
+### default=0 and omitempty
+
+At prebid/openrtb, any field that is integer with a default=0, is created with the `omitempty` property. The main reason to do that is saving some bytes on the transferred payload.
+
+However, at seedtag we think that some partners could have implemented openrtb in a way that this undefined values could be taken differently as 0 values, mostly for key fields as `imp.bidfloor`.
+
+The list of fields where we have removed the `omitempty` property:
+- req.imp.bidfloor
+- req.imp.instl
+- req.test
+- req.allimps
+
+### coppa
+
+Despiste not having a default, the `coppa` field is handled as `int` and `omitempty` on the official prebid/openrtb.
+
+We've moved this type to `*int` to be able to:
+- use nil when we don't want to add any info (omitempty will do teh rest)
+- use pointer to 0 when we want to explicitely say NO
+- use pointer to 1 when we want to explicitely say YES
+

--- a/openrtb2/bid_request.go
+++ b/openrtb2/bid_request.go
@@ -90,7 +90,7 @@ type BidRequest struct {
 	// Description:
 	//    Indicator of test mode in which auctions are not billable,
 	//    where 0 = live mode, 1 = test mode.
-	Test int8 `json:"test,omitempty"`
+	Test int8 `json:"test"`
 
 	// Attribute:
 	//   at
@@ -148,7 +148,7 @@ type BidRequest struct {
 	//   (e.g., all on the web page, all video spots such as pre/mid/post
 	//   roll) to support road-blocking. 0 = no or unknown, 1 = yes, the
 	//   impressions offered represent all that are available.
-	AllImps int8 `json:"allimps,omitempty"`
+	AllImps int8 `json:"allimps"`
 
 	// Attribute:
 	//   cur

--- a/openrtb2/imp.go
+++ b/openrtb2/imp.go
@@ -103,7 +103,7 @@ type Imp struct {
 	//   integer; default 0
 	// Description:
 	//   1 = the ad is interstitial or full screen, 0 = not interstitial.
-	Instl int8 `json:"instl,omitempty"`
+	Instl int8 `json:"instl"`
 
 	// Attribute:
 	//   tagid

--- a/openrtb2/regs.go
+++ b/openrtb2/regs.go
@@ -16,7 +16,7 @@ type Regs struct {
 	//   Flag indicating if this request is subject to the COPPA
 	//   regulations established by the USA FTC, where 0 = no, 1 = yes.
 	//   Refer to Section 7.5 for more information.
-	COPPA int8 `json:"coppa,omitempty"`
+	COPPA int8 `json:"coppa"`
 
 	// Attribute:
 	//   gdpr

--- a/openrtb2/regs.go
+++ b/openrtb2/regs.go
@@ -16,7 +16,7 @@ type Regs struct {
 	//   Flag indicating if this request is subject to the COPPA
 	//   regulations established by the USA FTC, where 0 = no, 1 = yes.
 	//   Refer to Section 7.5 for more information.
-	COPPA int8 `json:"coppa"`
+	COPPA *int8 `json:"coppa,omitempty"`
 
 	// Attribute:
 	//   gdpr


### PR DESCRIPTION
We want to send explicitly 0 for test, allimp and instl even though they are 0 by default and could be ommitted.

Coppa, on the other hand, is not default 0 and should be treated as a pointer (like gdpr)