### PR TITLE
added ifa type to device + remove omitempty from rwdd and ssai

### DIFF
--- a/openrtb2/device.go
+++ b/openrtb2/device.go
@@ -269,6 +269,15 @@ type Device struct {
 	IFA string `json:"ifa,omitempty"`
 
 	// Attribute:
+	//   ifa_type
+	// Type:
+	//   string
+	// Definition:
+	//   Provider of the IFA identifier. Not actually standard in the OpenRTB spec, but added here for convenience.
+	// https://iabtechlab.com/wp-content/uploads/2018/12/OTT-IFA-guidelines.final_Dec2018.pdf
+	IFAType string `json:"ifa_type,omitempty"`
+
+	// Attribute:
 	//   didsha1
 	// Type:
 	//   string; DEPRECATED

--- a/openrtb2/imp.go
+++ b/openrtb2/imp.go
@@ -175,7 +175,7 @@ type Imp struct {
 	//   an extra life in a game, or get a sponsored ad-free music
 	//   session. The reward is typically distributed after the video ad is
 	//   completed.
-	Rwdd int8 `json:"rwdd,omitempty"`
+	Rwdd int8 `json:"rwdd"`
 
 	// Attribute:
 	//   ssai
@@ -189,7 +189,7 @@ type Imp struct {
 	//   1 = all client-side (i.e., not server-side),
 	//   2 = assets stitched server-side but tracking pixels fired client-side,
 	//   3 = all server-side.
-	SSAI AdInsertion `json:"ssai,omitempty"`
+	SSAI AdInsertion `json:"ssai"`
 
 	// Attribute:
 	//   exp


### PR DESCRIPTION
**Device**
- added non standard ifa_type (https://iabtechlab.com/wp-content/uploads/2018/12/OTT-IFA-guidelines.final_Dec2018.pdf)

**Imp**
- removed omitempty from rwdd
- removed omitempty from ssai